### PR TITLE
Add step to clean build directory before running tests

### DIFF
--- a/coreruntime/README.md
+++ b/coreruntime/README.md
@@ -45,6 +45,7 @@ Pre-requisite: Setup mockserver by following the steps at [MockServerDocs](../mo
 ### Run Coreruntime tests
 ```sh
 cd $GIT_ROOT/coreruntime
+rm -rf build
 python3 build.py --testing
 cd build
 ./nimbletest
@@ -63,6 +64,7 @@ Pre-requisite: For linux since we are using Clang for compilation, appropriate g
 ### Run for nimbletest:
 ```sh
 cd $GIT_ROOT/coreruntime
+rm -rf build
 python3 build.py --testing --coverage
 cd build
 ./nimbletest


### PR DESCRIPTION
## Description
updates the coreruntime/README.md file to include a step for removing the existing build directory before executing any build or test commands.

Fixes #133

## Checklist:
- [ ] Added rm -rf build before the build step in "Run Coreruntime tests" section of README.md
- [ ] Added rm -rf build before the build step in "Run for nimbletest" section under "Get Coverage data" in README.md

