### PR TITLE
Updated anchor link for prerequisites

### DIFF
--- a/sdks/android/README.md
+++ b/sdks/android/README.md
@@ -396,7 +396,7 @@ Run instrumented tests on a connected device or emulator:
 
 **Prerequisites for Android Tests:**
 - Connected Android device or running emulator
-- Device meets the minimum requirements listed in [Prerequisites](#-prerequisites)
+- Device meets the minimum requirements listed in [Prerequisites](#prerequisites)
 - Proper configuration in `local.properties`
 
 ## API Reference


### PR DESCRIPTION
## Description
In the "Prerequisites for Android Tests" section, the link to the "Prerequisites" header used #-prerequisites, which is incorrect and does not navigate properly.

Fixes #134

## Checklist:
- [ ] Correct anchor link to Prerequisites in android documentation
