### PR TITLE
[ANDROID] Update workflow trigger for android instrumentation tests

### DIFF
--- a/.github/workflows/android-integration-tests.yml
+++ b/.github/workflows/android-integration-tests.yml
@@ -1,16 +1,16 @@
 name: Run Android Instrumentation Tests on Linux
 
 on:
-  pull_request_review:
-    types: [submitted]
-  push:
-    branches:
-      - main
+  pull_request_target:
+    types: [labeled, synchronize]
 
 jobs:
   test:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') }}
+    if: contains(github.event.pull_request.labels.*.name, 'ready-for-test')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         api-level: [31]
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup docker and start mock server
         run: |


### PR DESCRIPTION
## Description

This change allows workflow for running android instrumentation tests to have access to repository secrets on PRs from forked repos. To safeguard against unauthorized runs the workflow trigger has been updated so it will get invoked only in the following cases:-
- A repo maintainer adds the label `ready-for-test` on a PR
- A new commit is pushed to a PR already containing the label `ready-for-test`

This update needs to be merged to `main` before this workflow can be triggered.

Fixes # (issue)

## Checklist:
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Has user-facing changes. This may include API or behavior changes and performance improvements, etc
