### PR TITLE
Fix Android instrumentation tests

### DIFF
--- a/.github/workflows/android-integration-tests.yml
+++ b/.github/workflows/android-integration-tests.yml
@@ -16,6 +16,26 @@ jobs:
         api-level: [31]
 
     steps:
+      - name: Increase available storage space
+        shell: bash
+        run: |
+          sudo rm -rf /opt/az
+          sudo rm -rf /opt/google/chrome
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo rm -rf /opt/microsoft/msedge
+          sudo rm -rf /opt/microsoft/powershell
+          sudo rm -rf /usr/lib/dotnet
+          sudo rm -rf /usr/lib/firefox
+          sudo rm -rf /usr/lib/google-cloud-sdk
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/julia*
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/az_*
+          sudo rm -rf /usr/share/swift
+
       - name: checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description
To fix the Android instrumentation tests, increase the available storage space by deleting the unused software on the VM.