### PR TITLE
[IOS][SDK] Fix an int32_t vs int64_t bug

### DIFF
--- a/sdks/ios/deliteAI/Classes/sources/impl/controller/converter/InputConverter.m
+++ b/sdks/ios/deliteAI/Classes/sources/impl/controller/converter/InputConverter.m
@@ -367,7 +367,7 @@ void* convertProtoMapToVoidPointer(ProtoMapWrapper* wrappedClass) {
 
 void convertInt64ToCTensor(NSNumber* data, CTensor* req) {
     initialiseCTensor(req);
-    req->data = convertInt32ToVoidPointer(data);
+    req->data = convertInt64ToVoidPointer(data);
     req->dataType = INT64;
 }
 


### PR DESCRIPTION
## Description
Fixes an `int32_t` vs `int64_t` bug in the iOS SDK.